### PR TITLE
replaced deprecated import py4web.utils.tags with pydal.tools.tags

### DIFF
--- a/common.py
+++ b/common.py
@@ -9,8 +9,8 @@ from py4web import Session, Cache, Translator, Flash, DAL, Field, action
 from py4web.utils.mailer import Mailer
 from py4web.utils.auth import Auth
 from py4web.utils.downloader import downloader
-from py4web.utils.tags import Tags
 from py4web.utils.factories import ActionFactory
+from pydal.tools.tags import Tags
 from . import settings
 
 # #######################################################


### PR DESCRIPTION
Title pretty much says it all. Just updated the import for Tags.